### PR TITLE
feat: 비로그인 티켓 제출 기능 및 단체 관리 추가

### DIFF
--- a/backend/alembic/versions/004_update_user_and_gdrive_token.py
+++ b/backend/alembic/versions/004_update_user_and_gdrive_token.py
@@ -20,18 +20,20 @@ def upgrade() -> None:
     op.add_column('users', sa.Column('organization', sa.String(), nullable=True))
     
     # 2. UserGoogleToken 테이블의 access_token 컬럼을 nullable로 변경
-    # PostgreSQL 환경을 고려하여 alter_column 사용
-    op.alter_column('user_google_tokens', 'access_token',
-               existing_type=sa.String(),
-               nullable=True)
+    # batch_alter_table을 사용해 SQLite(로컬 개발 DB)와 PostgreSQL(운영) 모두 지원
+    with op.batch_alter_table('user_google_tokens') as batch_op:
+        batch_op.alter_column('access_token',
+                   existing_type=sa.String(),
+                   nullable=True)
 
 
 def downgrade() -> None:
     # 1. UserGoogleToken 테이블의 access_token 컬럼을 다시 NOT NULL로 변경
     # 주의: 기존 데이터에 NULL이 있을 경우 실패할 수 있으므로 downgrade 시 유의 필요
-    op.alter_column('user_google_tokens', 'access_token',
-               existing_type=sa.String(),
-               nullable=False)
+    with op.batch_alter_table('user_google_tokens') as batch_op:
+        batch_op.alter_column('access_token',
+                   existing_type=sa.String(),
+                   nullable=False)
     
     # 2. User 테이블에서 organization 컬럼 제거
     op.drop_column('users', 'organization')

--- a/backend/alembic/versions/005_add_organization_and_guest_submission.py
+++ b/backend/alembic/versions/005_add_organization_and_guest_submission.py
@@ -1,0 +1,132 @@
+"""Add organizations and guest_ticket_submissions tables
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-07-25 00:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. organizations 테이블 생성
+    op.create_table(
+        "organizations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=True, server_default="1"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_organizations_id", "organizations", ["id"], unique=False)
+    op.create_index("ix_organizations_name", "organizations", ["name"], unique=True)
+    op.create_index("ix_organizations_slug", "organizations", ["slug"], unique=True)
+
+    # 1-1. 기존 회원(users.organization)에 입력되어 있던 단체명들을
+    #      organizations 마스터 테이블로 백필 (중복/공백 제거)
+    connection = op.get_bind()
+    users_table = sa.table("users", sa.column("organization", sa.String()))
+    organizations_table = sa.table(
+        "organizations",
+        sa.column("name", sa.String()),
+        sa.column("slug", sa.String()),
+        sa.column("is_active", sa.Boolean()),
+    )
+
+    existing_orgs = connection.execute(
+        sa.select(users_table.c.organization).distinct()
+    ).fetchall()
+
+    seen: set[str] = set()
+    names_to_insert = []
+    for row in existing_orgs:
+        name = (row[0] or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names_to_insert.append(name)
+
+    if names_to_insert:
+        op.bulk_insert(
+            organizations_table,
+            [
+                {"name": name, "slug": None, "is_active": True}
+                for name in names_to_insert
+            ],
+        )
+
+    # 2. guest_ticket_submissions 테이블 생성
+    op.create_table(
+        "guest_ticket_submissions",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("phone", sa.String(), nullable=False),
+        sa.Column("verification_method", sa.String(), nullable=False),
+        sa.Column("eticket_object_key", sa.String(), nullable=True),
+        sa.Column("eticket_drive_url", sa.String(), nullable=True),
+        sa.Column("reservation_number", sa.String(), nullable=True),
+        sa.Column("passenger_name_en", sa.String(), nullable=True),
+        sa.Column("organization_id", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("admin_note", sa.Text(), nullable=True),
+        sa.Column("created_ticket_id", sa.String(), nullable=True),
+        sa.Column(
+            "submitted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_ticket_id"], ["tickets.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_guest_ticket_submissions_verification_method",
+        "guest_ticket_submissions",
+        ["verification_method"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_guest_ticket_submissions_organization_id",
+        "guest_ticket_submissions",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_guest_ticket_submissions_status",
+        "guest_ticket_submissions",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_guest_ticket_submissions_status", table_name="guest_ticket_submissions"
+    )
+    op.drop_index(
+        "ix_guest_ticket_submissions_organization_id",
+        table_name="guest_ticket_submissions",
+    )
+    op.drop_index(
+        "ix_guest_ticket_submissions_verification_method",
+        table_name="guest_ticket_submissions",
+    )
+    op.drop_table("guest_ticket_submissions")
+    op.drop_index("ix_organizations_slug", table_name="organizations")
+    op.drop_index("ix_organizations_name", table_name="organizations")
+    op.drop_index("ix_organizations_id", table_name="organizations")
+    op.drop_table("organizations")

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,16 @@ from sqlalchemy.orm import Session
 import models
 from alembic import command
 from database import engine, get_db
-from routers import auth, gdrive, master, need_posts, ticket_applications, tickets
+from routers import (
+    auth,
+    gdrive,
+    guest_submissions,
+    master,
+    need_posts,
+    organizations,
+    ticket_applications,
+    tickets,
+)
 
 # --- 🔒 필수 환경변수 검증 ---
 SECRET_KEY = os.environ.get("SECRET_KEY")
@@ -124,6 +133,8 @@ app.include_router(tickets.router)
 app.include_router(ticket_applications.router)
 app.include_router(need_posts.router)
 app.include_router(master.router)
+app.include_router(organizations.router)
+app.include_router(guest_submissions.router)
 
 
 # --- Annotated types ---

--- a/backend/models.py
+++ b/backend/models.py
@@ -217,6 +217,43 @@ class Airline(Base):
     is_active = Column(Boolean, default=True)
 
 
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    slug = Column(String, unique=True, index=True, nullable=True)  # 전용 제출 링크용
+    is_active = Column(Boolean, default=True)
+
+
+class GuestTicketSubmission(Base):
+    __tablename__ = "guest_ticket_submissions"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    phone = Column(String, nullable=False)
+    verification_method = Column(String, nullable=False, index=True)  # 'eticket_image', 'reservation_number'
+    eticket_object_key = Column(String, nullable=True)  # MinIO 오브젝트 키
+    eticket_drive_url = Column(String, nullable=True)  # 대표 관리자 구글 드라이브 백업 링크
+    reservation_number = Column(String, nullable=True)
+    passenger_name_en = Column(String, nullable=True)
+    organization_id = Column(
+        Integer, ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    status = Column(
+        String, nullable=False, default="pending", index=True
+    )  # 'pending', 'approved', 'rejected'
+    admin_note = Column(Text, nullable=True)
+    created_ticket_id = Column(
+        String, ForeignKey("tickets.id", ondelete="SET NULL"), nullable=True
+    )
+
+    submitted_at = Column(DateTime(timezone=True), server_default=func.now())
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
+
+    organization = relationship("Organization")
+    created_ticket = relationship("Ticket")
+
+
 class UserGoogleToken(Base):
     __tablename__ = "user_google_tokens"
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ psycopg2-binary
 google-api-python-client
 google-auth-oauthlib
 google-auth-httplib2
+minio
 
 opentelemetry-distro
 opentelemetry-exporter-otlp

--- a/backend/routers/guest_submissions.py
+++ b/backend/routers/guest_submissions.py
@@ -1,0 +1,231 @@
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    UploadFile,
+    status,
+)
+from fastapi.responses import Response
+from sqlalchemy.orm import Session, joinedload
+
+import models
+import schemas
+from database import get_db
+from routers.auth import AdminUser
+from services import gdrive_service, storage_service
+
+router = APIRouter(prefix="/api/guest-submissions", tags=["Guest Ticket Submissions"])
+
+# --- Annotated types ---
+DBSession = Annotated[Session, Depends(get_db)]
+
+ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp", "application/pdf"}
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB
+
+
+@router.post("", response_model=schemas.GuestTicketSubmission, status_code=status.HTTP_201_CREATED)
+async def create_guest_submission(
+    db: DBSession,
+    background_tasks: BackgroundTasks,
+    phone: Annotated[str, Form()],
+    verification_method: Annotated[schemas.GuestSubmissionVerificationMethod, Form()],
+    reservation_number: Annotated[str | None, Form()] = None,
+    passenger_name_en: Annotated[str | None, Form()] = None,
+    organization_id: Annotated[int | None, Form()] = None,
+    eticket_image: Annotated[UploadFile | None, File()] = None,
+) -> models.GuestTicketSubmission:
+    """
+    Public endpoint. Anyone (no login required) can submit their flight ticket info
+    to volunteer spare pet-carrying capacity.
+    """
+    if not phone.strip():
+        raise HTTPException(status_code=400, detail="전화번호를 입력해주세요.")
+
+    if verification_method == schemas.GuestSubmissionVerificationMethod.eticket_image:
+        if not eticket_image:
+            raise HTTPException(
+                status_code=400, detail="e티켓 이미지를 첨부해주세요."
+            )
+    else:
+        if not (reservation_number and reservation_number.strip()) or not (
+            passenger_name_en and passenger_name_en.strip()
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="예약번호와 탑승객 영문명을 모두 입력해주세요.",
+            )
+
+    if organization_id is not None:
+        organization = (
+            db.query(models.Organization)
+            .filter(models.Organization.id == organization_id)
+            .first()
+        )
+        if not organization:
+            raise HTTPException(status_code=404, detail="단체를 찾을 수 없습니다.")
+
+    eticket_object_key = None
+    if eticket_image:
+        if eticket_image.content_type not in ALLOWED_CONTENT_TYPES:
+            raise HTTPException(
+                status_code=400, detail="이미지 또는 PDF 파일만 업로드할 수 있습니다."
+            )
+        contents = await eticket_image.read()
+        if len(contents) > MAX_UPLOAD_SIZE:
+            raise HTTPException(
+                status_code=400, detail="파일 크기는 10MB를 초과할 수 없습니다."
+            )
+        ext = os.path.splitext(eticket_image.filename or "")[1]
+        eticket_object_key = f"{uuid.uuid4()}{ext}"
+        try:
+            storage_service.upload_bytes(
+                eticket_object_key, contents, eticket_image.content_type
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=502, detail="이미지 저장소 연결에 실패했습니다."
+            ) from e
+
+    db_submission = models.GuestTicketSubmission(
+        phone=phone,
+        verification_method=verification_method.value,
+        eticket_object_key=eticket_object_key,
+        reservation_number=reservation_number
+        if verification_method
+        == schemas.GuestSubmissionVerificationMethod.reservation_number
+        else None,
+        passenger_name_en=passenger_name_en
+        if verification_method
+        == schemas.GuestSubmissionVerificationMethod.reservation_number
+        else None,
+        organization_id=organization_id,
+    )
+    db.add(db_submission)
+    db.commit()
+    db.refresh(db_submission)
+
+    if eticket_object_key:
+        background_tasks.add_task(
+            gdrive_service.backup_guest_submission_to_drive,
+            db,
+            db_submission.id,
+            eticket_object_key,
+            eticket_image.content_type,
+        )
+
+    return db_submission
+
+
+@router.get("", response_model=list[schemas.GuestTicketSubmission])
+def list_guest_submissions(
+    db: DBSession,
+    current_admin: AdminUser,
+    submission_status: schemas.GuestSubmissionStatus | None = None,
+) -> list[models.GuestTicketSubmission]:
+    query = db.query(models.GuestTicketSubmission).options(
+        joinedload(models.GuestTicketSubmission.organization)
+    )
+    if submission_status:
+        query = query.filter(models.GuestTicketSubmission.status == submission_status.value)
+    return query.order_by(models.GuestTicketSubmission.submitted_at.desc()).all()
+
+
+@router.get("/{submission_id}/image")
+def get_guest_submission_image(
+    submission_id: str, db: DBSession, current_admin: AdminUser
+) -> Response:
+    submission = (
+        db.query(models.GuestTicketSubmission)
+        .filter(models.GuestTicketSubmission.id == submission_id)
+        .first()
+    )
+    if not submission or not submission.eticket_object_key:
+        raise HTTPException(status_code=404, detail="이미지를 찾을 수 없습니다.")
+
+    try:
+        content, content_type = storage_service.get_object(submission.eticket_object_key)
+    except Exception as e:
+        raise HTTPException(
+            status_code=404, detail="이미지를 찾을 수 없습니다."
+        ) from e
+
+    return Response(content=content, media_type=content_type)
+
+
+@router.post("/{submission_id}/approve", response_model=schemas.Ticket)
+def approve_guest_submission(
+    submission_id: str,
+    approve_in: schemas.GuestSubmissionApprove,
+    db: DBSession,
+    current_admin: AdminUser,
+) -> models.Ticket:
+    submission = (
+        db.query(models.GuestTicketSubmission)
+        .filter(models.GuestTicketSubmission.id == submission_id)
+        .first()
+    )
+    if not submission:
+        raise HTTPException(status_code=404, detail="제출 내역을 찾을 수 없습니다.")
+    if submission.status != "pending":
+        raise HTTPException(
+            status_code=400, detail="이미 처리된 제출 내역입니다."
+        )
+
+    owner_user_id = approve_in.owner_user_id
+    if owner_user_id:
+        owner = db.query(models.User).filter(models.User.id == owner_user_id).first()
+        if not owner:
+            raise HTTPException(status_code=404, detail="선택한 회원을 찾을 수 없습니다.")
+
+    ticket_data = approve_in.model_dump(exclude={"owner_user_id"})
+    db_ticket = models.Ticket(
+        **ticket_data,
+        status="sharing",
+        created_by_id=owner_user_id,
+        owner_id=owner_user_id,
+    )
+    db.add(db_ticket)
+    db.commit()
+    db.refresh(db_ticket)
+
+    submission.status = "approved"
+    submission.reviewed_at = datetime.now(timezone.utc)
+    submission.created_ticket_id = db_ticket.id
+    db.commit()
+
+    return db_ticket
+
+
+@router.post("/{submission_id}/reject", response_model=schemas.GuestTicketSubmission)
+def reject_guest_submission(
+    submission_id: str,
+    reject_in: schemas.GuestSubmissionReject,
+    db: DBSession,
+    current_admin: AdminUser,
+) -> models.GuestTicketSubmission:
+    submission = (
+        db.query(models.GuestTicketSubmission)
+        .filter(models.GuestTicketSubmission.id == submission_id)
+        .first()
+    )
+    if not submission:
+        raise HTTPException(status_code=404, detail="제출 내역을 찾을 수 없습니다.")
+    if submission.status != "pending":
+        raise HTTPException(
+            status_code=400, detail="이미 처리된 제출 내역입니다."
+        )
+
+    submission.status = "rejected"
+    submission.admin_note = reject_in.admin_note
+    submission.reviewed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(submission)
+    return submission

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -1,0 +1,96 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+import models
+import schemas
+from database import get_db
+from routers.auth import AdminUser
+
+router = APIRouter(prefix="/api/organizations", tags=["organizations"])
+
+# --- Annotated types ---
+DBSession = Annotated[Session, Depends(get_db)]
+
+
+@router.get("", response_model=list[schemas.Organization])
+def get_organizations(db: DBSession) -> list[models.Organization]:
+    return db.query(models.Organization).order_by(models.Organization.name).all()
+
+
+@router.get("/by-slug/{slug}", response_model=schemas.Organization)
+def get_organization_by_slug(slug: str, db: DBSession) -> models.Organization:
+    organization = (
+        db.query(models.Organization)
+        .filter(models.Organization.slug == slug, models.Organization.is_active.is_(True))
+        .first()
+    )
+    if not organization:
+        raise HTTPException(status_code=404, detail="단체를 찾을 수 없습니다.")
+    return organization
+
+
+@router.post("", response_model=schemas.Organization)
+def create_organization(
+    organization: schemas.OrganizationCreate,
+    db: DBSession,
+    current_admin: AdminUser = None,
+) -> models.Organization:
+    db_organization = models.Organization(**organization.model_dump())
+    db.add(db_organization)
+    try:
+        db.commit()
+        db.refresh(db_organization)
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=400, detail="이미 존재하는 단체명 또는 슬러그입니다."
+        ) from e
+    return db_organization
+
+
+@router.put("/{organization_id}", response_model=schemas.Organization)
+def update_organization(
+    organization_id: int,
+    organization_update: schemas.OrganizationUpdate,
+    db: DBSession,
+    current_admin: AdminUser = None,
+) -> models.Organization:
+    db_organization = (
+        db.query(models.Organization)
+        .filter(models.Organization.id == organization_id)
+        .first()
+    )
+    if not db_organization:
+        raise HTTPException(status_code=404, detail="단체를 찾을 수 없습니다.")
+
+    update_data = organization_update.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_organization, key, value)
+
+    try:
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=400, detail="이미 존재하는 단체명 또는 슬러그입니다."
+        ) from e
+    db.refresh(db_organization)
+    return db_organization
+
+
+@router.delete("/{organization_id}")
+def delete_organization(
+    organization_id: int, db: DBSession, current_admin: AdminUser = None
+) -> dict[str, str]:
+    db_organization = (
+        db.query(models.Organization)
+        .filter(models.Organization.id == organization_id)
+        .first()
+    )
+    if not db_organization:
+        raise HTTPException(status_code=404, detail="단체를 찾을 수 없습니다.")
+    db.delete(db_organization)
+    db.commit()
+    return {"detail": "단체가 삭제되었습니다."}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -322,4 +322,88 @@ class Airline(AirlineBase):
 
     class Config:
         from_attributes = True
-s = True
+
+
+# ======================================================================================
+# Organization Schemas
+# ======================================================================================
+class OrganizationBase(BaseModel):
+    name: str
+    slug: str | None = None
+    is_active: bool | None = True
+
+    @field_validator("slug")
+    @classmethod
+    def slug_format(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        if not re.fullmatch(r"[a-z0-9-]+", v):
+            raise ValueError("슬러그는 영문 소문자, 숫자, 하이픈(-)만 사용할 수 있습니다.")
+        return v
+
+
+class OrganizationCreate(OrganizationBase):
+    pass
+
+
+class OrganizationUpdate(BaseModel):
+    name: str | None = None
+    slug: str | None = None
+    is_active: bool | None = None
+
+    @field_validator("slug")
+    @classmethod
+    def slug_format(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        if not re.fullmatch(r"[a-z0-9-]+", v):
+            raise ValueError("슬러그는 영문 소문자, 숫자, 하이픈(-)만 사용할 수 있습니다.")
+        return v
+
+
+class Organization(OrganizationBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+# ======================================================================================
+# Guest Ticket Submission Schemas
+# ======================================================================================
+class GuestSubmissionVerificationMethod(str, Enum):
+    eticket_image = "eticket_image"
+    reservation_number = "reservation_number"
+
+
+class GuestSubmissionStatus(str, Enum):
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+
+
+class GuestTicketSubmission(BaseModel):
+    id: str
+    phone: str
+    verification_method: GuestSubmissionVerificationMethod
+    reservation_number: str | None = None
+    passenger_name_en: str | None = None
+    organization_id: int | None = None
+    organization: Organization | None = None
+    eticket_drive_url: str | None = None
+    status: GuestSubmissionStatus
+    admin_note: str | None = None
+    created_ticket_id: str | None = None
+    submitted_at: datetime
+    reviewed_at: datetime | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class GuestSubmissionReject(BaseModel):
+    admin_note: str | None = None
+
+
+class GuestSubmissionApprove(TicketBase):
+    owner_user_id: str | None = None

--- a/backend/services/gdrive_service.py
+++ b/backend/services/gdrive_service.py
@@ -7,9 +7,11 @@ from typing import Any
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import Flow
 from googleapiclient.discovery import build
+from googleapiclient.http import MediaInMemoryUpload
 from sqlalchemy.orm import Session
 
 import models
+from services import storage_service
 
 # Google API Scopes
 SCOPES = [
@@ -377,6 +379,116 @@ def list_user_folders(user_token: models.UserGoogleToken) -> list[dict[str, str]
     ).execute()
 
     return results.get("files", [])
+
+
+def get_or_create_folder(
+    user_token: models.UserGoogleToken,
+    folder_name: str,
+    parent_id: str | None = None,
+) -> str:
+    """
+    parent_id 아래에서 folder_name 폴더를 찾고, 없으면 새로 생성합니다.
+    """
+    service = get_drive_service(user_token)
+    query = (
+        f"name = '{folder_name}' and "
+        "mimeType = 'application/vnd.google-apps.folder' and trashed = false"
+    )
+    if parent_id:
+        query += f" and '{parent_id}' in parents"
+
+    results = service.files().list(q=query, fields="files(id, name)").execute()
+    folders = results.get("files", [])
+    if folders:
+        return folders[0]["id"]
+
+    file_metadata: dict[str, Any] = {
+        "name": folder_name,
+        "mimeType": "application/vnd.google-apps.folder",
+    }
+    if parent_id:
+        file_metadata["parents"] = [parent_id]
+    folder = service.files().create(body=file_metadata, fields="id").execute()
+    return folder.get("id")
+
+
+def upload_file_to_drive(
+    user_token: models.UserGoogleToken,
+    filename: str,
+    content: bytes,
+    mime_type: str,
+    folder_id: str | None = None,
+) -> str | None:
+    """
+    파일 바이트를 사용자의 구글 드라이브에 업로드하고 파일 ID를 반환합니다.
+    """
+    service = get_drive_service(user_token)
+    file_metadata: dict[str, Any] = {"name": filename}
+    if folder_id:
+        file_metadata["parents"] = [folder_id]
+
+    media = MediaInMemoryUpload(content, mimetype=mime_type, resumable=False)
+    uploaded = service.files().create(
+        body=file_metadata, media_body=media, fields="id, webViewLink"
+    ).execute()
+    return uploaded.get("id")
+
+
+GDRIVE_UPLOAD_ADMIN_EMAIL = os.environ.get("GDRIVE_UPLOAD_ADMIN_EMAIL")
+GUEST_SUBMISSION_FOLDER_NAME = "이동봉사_티켓제출_이미지"
+
+
+def backup_guest_submission_to_drive(
+    db: Session,
+    submission_id: str,
+    object_key: str,
+    mime_type: str,
+) -> None:
+    """
+    [백그라운드] 비로그인 제출자의 e티켓 이미지(MinIO에 저장됨)를
+    대표 관리자(GDRIVE_UPLOAD_ADMIN_EMAIL)의 구글 드라이브에 백업 업로드합니다.
+    대표 관리자 미설정/미연동 시 조용히 건너뜁니다. MinIO 원본은 그대로 유지되며,
+    이 업로드는 어디까지나 백업 용도입니다.
+    """
+    if not GDRIVE_UPLOAD_ADMIN_EMAIL:
+        return
+
+    admin_user = (
+        db.query(models.User)
+        .filter(models.User.email == GDRIVE_UPLOAD_ADMIN_EMAIL)
+        .first()
+    )
+    if not admin_user:
+        return
+
+    user_token = (
+        db.query(models.UserGoogleToken)
+        .filter(models.UserGoogleToken.user_id == admin_user.id)
+        .first()
+    )
+    if not user_token or not user_token.access_token:
+        return
+
+    submission = (
+        db.query(models.GuestTicketSubmission)
+        .filter(models.GuestTicketSubmission.id == submission_id)
+        .first()
+    )
+    if not submission:
+        return
+
+    try:
+        content, _ = storage_service.get_object(object_key)
+        folder_id = get_or_create_folder(
+            user_token, GUEST_SUBMISSION_FOLDER_NAME, parent_id=user_token.root_folder_id
+        )
+        file_id = upload_file_to_drive(user_token, object_key, content, mime_type, folder_id)
+        if file_id:
+            submission.eticket_drive_url = f"https://drive.google.com/file/d/{file_id}/view"
+            db.commit()
+    except Exception as e:
+        print(f"Error backing up guest submission to GDrive: {e}")
+        db.rollback()
 
 
 def create_root_sync_folder(

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -1,0 +1,50 @@
+import io
+import os
+from functools import lru_cache
+
+from minio import Minio
+
+MINIO_ENDPOINT = os.environ.get("MINIO_ENDPOINT", "localhost:9000")
+MINIO_ACCESS_KEY = os.environ.get("MINIO_ACCESS_KEY", "")
+MINIO_SECRET_KEY = os.environ.get("MINIO_SECRET_KEY", "")
+MINIO_SECURE = os.environ.get("MINIO_SECURE", "false").lower() == "true"
+MINIO_BUCKET = os.environ.get("MINIO_BUCKET", "eticket-images")
+
+
+@lru_cache(maxsize=1)
+def get_client() -> Minio:
+    client = Minio(
+        MINIO_ENDPOINT,
+        access_key=MINIO_ACCESS_KEY,
+        secret_key=MINIO_SECRET_KEY,
+        secure=MINIO_SECURE,
+    )
+    if not client.bucket_exists(MINIO_BUCKET):
+        client.make_bucket(MINIO_BUCKET)
+    return client
+
+
+def upload_bytes(object_key: str, content: bytes, content_type: str) -> None:
+    client = get_client()
+    client.put_object(
+        MINIO_BUCKET,
+        object_key,
+        io.BytesIO(content),
+        length=len(content),
+        content_type=content_type,
+    )
+
+
+def get_object(object_key: str) -> tuple[bytes, str]:
+    """
+    반환: (파일 바이트, content-type)
+    """
+    client = get_client()
+    response = client.get_object(MINIO_BUCKET, object_key)
+    try:
+        content = response.read()
+        content_type = response.headers.get("content-type", "application/octet-stream")
+    finally:
+        response.close()
+        response.release_conn()
+    return content, content_type

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import GiveView from './pages/GiveView';
 import MyTicketsView from './pages/MyTicketsView';
 import MyApplicationsView from './pages/MyApplicationsView';
 import AdminView from './pages/AdminView';
+import GuestTicketSubmitView from './pages/GuestTicketSubmitView';
 
 function App() {
   return (
@@ -28,7 +29,10 @@ function AppContent() {
   return (
     <Routes>
       {!user ? (
-        <Route path="*" element={<LoginScreen />} />
+        <>
+          <Route path="/apply" element={<GuestTicketSubmitView />} />
+          <Route path="*" element={<LoginScreen />} />
+        </>
       ) : (
         <Route path="/" element={<MainLayout />}>
           <Route index element={<Navigate to="/schedules" />} />

--- a/frontend/src/components/modals/GuestSubmissionReviewModal.jsx
+++ b/frontend/src/components/modals/GuestSubmissionReviewModal.jsx
@@ -1,0 +1,373 @@
+import { useState, useEffect } from 'react';
+import Modal from '../ui/Modal';
+import SelectField from '../ui/SelectField';
+import { useAuth } from '../../hooks/useAuth';
+
+const emptyForm = {
+    title: '',
+    arrivalAirport: '',
+    departureDate: '',
+    departureTime: '',
+    arrivalDate: '',
+    arrivalTime: '',
+    flightInfo: '',
+    airline: '',
+    capacity: 1,
+    cabinCapacity: 0,
+    cargoCapacity: 0,
+    managerName: '',
+    contact: '',
+    memo: '',
+    ownerUserId: ''
+};
+
+export default function GuestSubmissionReviewModal({ isOpen, onClose, submission, onReviewed }) {
+    const { apiClient, airports, airlines } = useAuth();
+
+    const [form, setForm] = useState(emptyForm);
+    const [users, setUsers] = useState([]);
+    const [imageUrl, setImageUrl] = useState('');
+    const [showReject, setShowReject] = useState(false);
+    const [adminNote, setAdminNote] = useState('');
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        if (!isOpen || !submission) {
+            setForm(emptyForm);
+            setShowReject(false);
+            setAdminNote('');
+            setError('');
+            return;
+        }
+
+        setForm({
+            ...emptyForm,
+            contact: submission.phone || ''
+        });
+
+        apiClient.get('/users')
+            .then(res => setUsers(res.data))
+            .catch(() => setUsers([]));
+
+        if (submission.verification_method === 'eticket_image') {
+            apiClient.get(`/guest-submissions/${submission.id}/image`, { responseType: 'blob' })
+                .then(res => setImageUrl(URL.createObjectURL(res.data)))
+                .catch(() => setImageUrl(''));
+        } else {
+            setImageUrl('');
+        }
+    }, [isOpen, submission, apiClient]);
+
+    useEffect(() => {
+        return () => {
+            if (imageUrl) URL.revokeObjectURL(imageUrl);
+        };
+    }, [imageUrl]);
+
+    if (!submission) return null;
+
+    const handleChange = (field, value) => {
+        setForm(prev => {
+            const newForm = { ...prev, [field]: value };
+            if (field === 'departureDate' && (!prev.arrivalDate || prev.arrivalDate < value)) {
+                newForm.arrivalDate = value;
+            }
+            return newForm;
+        });
+    };
+
+    const handleApprove = async () => {
+        setError('');
+        if (!form.departureDate) {
+            setError('출발일을 선택해주세요.');
+            return;
+        }
+        if (!form.arrivalAirport) {
+            setError('도착 공항을 선택하거나 입력해주세요.');
+            return;
+        }
+        if (!form.airline) {
+            setError('항공사를 선택하거나 입력해주세요.');
+            return;
+        }
+        if (!form.managerName.trim()) {
+            setError('담당자명을 입력해주세요.');
+            return;
+        }
+
+        const payload = {
+            title: form.title.trim() || '티켓 나눔 (상세 확인)',
+            arrival_airport: form.arrivalAirport,
+            departure_date: form.departureDate,
+            departure_time: form.departureTime,
+            arrival_date: form.arrivalDate || form.departureDate,
+            arrival_time: form.arrivalTime,
+            flight_info: form.flightInfo,
+            airline: form.airline,
+            capacity: form.capacity,
+            cabin_capacity: form.cabinCapacity,
+            cargo_capacity: form.cargoCapacity,
+            manager_name: form.managerName,
+            contact: form.contact,
+            memo: form.memo,
+            owner_user_id: form.ownerUserId || null
+        };
+
+        try {
+            await apiClient.post(`/guest-submissions/${submission.id}/approve`, payload);
+            onReviewed();
+            onClose();
+        } catch (err) {
+            setError(err.response?.data?.detail || '승인에 실패했습니다.');
+        }
+    };
+
+    const handleReject = async () => {
+        try {
+            await apiClient.post(`/guest-submissions/${submission.id}/reject`, { admin_note: adminNote });
+            onReviewed();
+            onClose();
+        } catch (err) {
+            setError(err.response?.data?.detail || '반려에 실패했습니다.');
+        }
+    };
+
+    const footer = (
+        <div className="flex items-center justify-end w-full gap-2">
+            <button
+                className="px-4 py-2 text-sm font-bold rounded-md bg-secondary text-secondary-foreground border border-border hover:bg-muted transition-colors"
+                onClick={onClose}
+            >
+                취소
+            </button>
+            <button
+                className="px-4 py-2 text-sm font-bold rounded-md bg-destructive/10 text-destructive border border-destructive/20 hover:bg-destructive/20 transition-all"
+                onClick={() => setShowReject(v => !v)}
+            >
+                반려
+            </button>
+            <button
+                className="px-6 py-2 text-sm font-bold transition-all rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm"
+                onClick={handleApprove}
+            >
+                승인하기
+            </button>
+        </div>
+    );
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="📋 티켓 제출 검토" footer={footer} error={error}>
+            <div className="space-y-6">
+                <div className="p-4 rounded-xl border-2 border-border bg-muted/30 space-y-2">
+                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">제출 정보</div>
+                    <div className="text-sm"><span className="font-bold">전화번호:</span> {submission.phone}</div>
+                    {submission.organization && (
+                        <div className="text-sm"><span className="font-bold">지정 단체:</span> {submission.organization.name}</div>
+                    )}
+                    {submission.verification_method === 'eticket_image' ? (
+                        <>
+                            {imageUrl ? (
+                                <a href={imageUrl} target="_blank" rel="noreferrer">
+                                    <img src={imageUrl} alt="e티켓" className="max-h-64 rounded-lg border-2 border-border mt-2" />
+                                </a>
+                            ) : (
+                                <div className="text-xs text-muted-foreground">이미지를 불러오는 중...</div>
+                            )}
+                            {submission.eticket_drive_url && (
+                                <a
+                                    href={submission.eticket_drive_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="inline-block text-xs font-bold text-primary hover:underline"
+                                >
+                                    📁 구글 드라이브 백업본 보기
+                                </a>
+                            )}
+                        </>
+                    ) : (
+                        <>
+                            <div className="text-sm"><span className="font-bold">예약번호:</span> {submission.reservation_number}</div>
+                            <div className="text-sm"><span className="font-bold">탑승객 영문명:</span> {submission.passenger_name_en}</div>
+                        </>
+                    )}
+                </div>
+
+                {showReject ? (
+                    <div className="space-y-2">
+                        <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">반려 사유</label>
+                        <textarea
+                            className="flex min-h-[80px] w-full rounded-lg border-2 border-border bg-background px-4 py-3 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                            value={adminNote}
+                            onChange={e => setAdminNote(e.target.value)}
+                            placeholder="반려 사유를 입력해주세요..."
+                        />
+                        <button
+                            className="w-full h-11 text-sm font-bold rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-all"
+                            onClick={handleReject}
+                        >
+                            반려 확정
+                        </button>
+                    </div>
+                ) : (
+                    <>
+                        <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">실제 항공편 정보 입력</div>
+
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">티켓 제목 (미입력 시 자동 생성)</label>
+                            <input
+                                className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                value={form.title}
+                                onChange={e => handleChange('title', e.target.value)}
+                                placeholder="예: 4월 뉴욕행 티켓 나눔합니다"
+                            />
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                    출발일<span className="text-destructive ml-0.5">*</span>
+                                </label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    type="date"
+                                    value={form.departureDate}
+                                    onChange={e => handleChange('departureDate', e.target.value)}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">출발 시간</label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    type="time"
+                                    value={form.departureTime}
+                                    onChange={e => handleChange('departureTime', e.target.value)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                    도착일<span className="text-destructive ml-0.5">*</span>
+                                </label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    type="date"
+                                    value={form.arrivalDate}
+                                    onChange={e => handleChange('arrivalDate', e.target.value)}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">도착 시간</label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    type="time"
+                                    value={form.arrivalTime}
+                                    onChange={e => handleChange('arrivalTime', e.target.value)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <SelectField
+                                label={<>도착 공항<span className="text-destructive ml-0.5">*</span></>}
+                                options={airports}
+                                value={form.arrivalAirport}
+                                onChange={val => handleChange('arrivalAirport', val)}
+                                placeholder="공항 선택 또는 직접 입력"
+                            />
+                            <SelectField
+                                label={<>항공사<span className="text-destructive ml-0.5">*</span></>}
+                                options={airlines}
+                                value={form.airline}
+                                onChange={val => handleChange('airline', val)}
+                                placeholder="항공사 선택 또는 직접 입력"
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">항공편 정보</label>
+                            <input
+                                className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                value={form.flightInfo}
+                                onChange={e => handleChange('flightInfo', e.target.value)}
+                                placeholder="예: ICN → JFK KE081"
+                            />
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">기내(마리)</label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    type="number"
+                                    min="0"
+                                    value={form.cabinCapacity === 0 ? '' : form.cabinCapacity}
+                                    onChange={e => handleChange('cabinCapacity', e.target.value)}
+                                    placeholder="0"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">수하물(마리)</label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    type="number"
+                                    min="0"
+                                    value={form.cargoCapacity === 0 ? '' : form.cargoCapacity}
+                                    onChange={e => handleChange('cargoCapacity', e.target.value)}
+                                    placeholder="0"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                    담당자명<span className="text-destructive ml-0.5">*</span>
+                                </label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    value={form.managerName}
+                                    onChange={e => handleChange('managerName', e.target.value)}
+                                    placeholder="제출자 이름"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">연락처</label>
+                                <input
+                                    className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    value={form.contact}
+                                    onChange={e => handleChange('contact', e.target.value)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">소유 회원 지정 (선택)</label>
+                            <select
+                                className="h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                value={form.ownerUserId}
+                                onChange={e => handleChange('ownerUserId', e.target.value)}
+                            >
+                                <option value="">지정 안 함 (관리자 관리)</option>
+                                {users.map(u => (
+                                    <option key={u.id} value={u.id}>{u.name} ({u.email}){u.organization ? ` - ${u.organization}` : ''}</option>
+                                ))}
+                            </select>
+                        </div>
+
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">메모</label>
+                            <textarea
+                                className="flex min-h-[80px] w-full rounded-lg border-2 border-border bg-background px-4 py-3 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                value={form.memo}
+                                onChange={e => handleChange('memo', e.target.value)}
+                                placeholder="추가 정보..."
+                            />
+                        </div>
+                    </>
+                )}
+            </div>
+        </Modal>
+    );
+}

--- a/frontend/src/components/modals/OrganizationModal.jsx
+++ b/frontend/src/components/modals/OrganizationModal.jsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react';
+import Modal from '../ui/Modal';
+
+export default function OrganizationModal({ isOpen, onClose, organization, onSaved, apiClient }) {
+    const [form, setForm] = useState({
+        name: '',
+        slug: '',
+        is_active: true
+    });
+    const [error, setError] = useState('');
+
+    const isEditing = !!organization;
+
+    useEffect(() => {
+        if (isEditing) {
+            setForm({
+                name: organization.name || '',
+                slug: organization.slug || '',
+                is_active: organization.is_active ?? true
+            });
+        } else {
+            setForm({
+                name: '',
+                slug: '',
+                is_active: true
+            });
+        }
+    }, [organization, isEditing, isOpen]);
+
+    const handleSubmit = async () => {
+        try {
+            if (isEditing) {
+                await apiClient.put(`/organizations/${organization.id}`, form);
+            } else {
+                await apiClient.post('/organizations', form);
+            }
+            onSaved();
+            onClose();
+        } catch (err) {
+            setError(err.response?.data?.detail || '저장에 실패했습니다.');
+        }
+    };
+
+    const footer = (
+        <div className="flex items-center justify-end w-full gap-2">
+            <button
+                className="px-4 py-2 text-sm font-bold rounded-md bg-secondary text-secondary-foreground border border-border hover:bg-muted transition-colors"
+                onClick={onClose}
+            >
+                취소
+            </button>
+            <button
+                className="px-6 py-2 text-sm font-bold transition-all rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm"
+                onClick={handleSubmit}
+            >
+                저장하기
+            </button>
+        </div>
+    );
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title={isEditing ? '🏢 단체 수정' : '🏢 단체 등록'} footer={footer}>
+            <div className="space-y-6">
+                <div className="space-y-2">
+                    <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">단체명</label>
+                    <input
+                        className="flex h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                        value={form.name}
+                        onChange={e => setForm({...form, name: e.target.value})}
+                        placeholder="예: 해봉이네"
+                    />
+                </div>
+                <div className="space-y-2">
+                    <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">전용 제출 링크 슬러그 (선택)</label>
+                    <input
+                        className="flex h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                        value={form.slug}
+                        onChange={e => setForm({...form, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-')})}
+                        placeholder="예: adogs"
+                    />
+                    {form.slug && (
+                        <div className="px-3 py-2 text-[11px] font-mono text-muted-foreground bg-muted/30 rounded-lg border border-border/50 break-all">
+                            {`${window.location.origin}/apply?org=${form.slug}`}
+                        </div>
+                    )}
+                    <p className="text-[11px] text-muted-foreground ml-1">이 슬러그를 넣은 링크로 들어오면 소속 단체가 자동으로 고정됩니다.</p>
+                </div>
+                <div className="flex items-center gap-3 p-4 rounded-xl border-2 border-border bg-muted/30">
+                    <label className="relative inline-flex items-center cursor-pointer">
+                        <input
+                            type="checkbox"
+                            className="sr-only peer"
+                            checked={form.is_active}
+                            onChange={e => setForm({...form, is_active: e.target.checked})}
+                        />
+                        <div className="w-11 h-6 bg-border rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                        <span className="ml-3 text-sm font-bold text-foreground">사용 여부</span>
+                    </label>
+                </div>
+                {error && (
+                    <div className="px-3 py-2 text-xs font-medium text-destructive bg-destructive/10 border border-destructive/20 rounded-lg">
+                        {error}
+                    </div>
+                )}
+            </div>
+        </Modal>
+    );
+}

--- a/frontend/src/pages/AdminView.jsx
+++ b/frontend/src/pages/AdminView.jsx
@@ -4,15 +4,19 @@ import { useModal } from '../hooks/useModal';
 import RegisterUserModal from '../components/modals/RegisterUserModal';
 import AirportModal from '../components/modals/AirportModal';
 import AirlineModal from '../components/modals/AirlineModal';
+import OrganizationModal from '../components/modals/OrganizationModal';
+import GuestSubmissionReviewModal from '../components/modals/GuestSubmissionReviewModal';
 
 export default function AdminView() {
     const { apiClient, fetchStaticData } = useAuth();
     const [activeTab, setActiveTab] = useState('users');
-    
+
     // 데이터 상태
     const [users, setUsers] = useState([]);
     const [airports, setAirports] = useState([]);
     const [airlines, setAirlines] = useState([]);
+    const [organizations, setOrganizations] = useState([]);
+    const [submissions, setSubmissions] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
 
@@ -22,6 +26,8 @@ export default function AdminView() {
     const userModal = useModal();
     const airportModal = useModal();
     const airlineModal = useModal();
+    const organizationModal = useModal();
+    const submissionModal = useModal();
 
     const fetchData = useCallback(async () => {
         setLoading(true);
@@ -36,6 +42,12 @@ export default function AdminView() {
             } else if (activeTab === 'airlines') {
                 const res = await apiClient.get('/master/airlines');
                 setAirlines(res.data);
+            } else if (activeTab === 'organizations') {
+                const res = await apiClient.get('/organizations');
+                setOrganizations(res.data);
+            } else if (activeTab === 'submissions') {
+                const res = await apiClient.get('/guest-submissions');
+                setSubmissions(res.data);
             }
         } catch {
             setError('데이터를 불러오는데 실패했습니다.');
@@ -57,6 +69,7 @@ export default function AdminView() {
         setSelectedItem(item);
         if (activeTab === 'airports') airportModal.openModal();
         else if (activeTab === 'airlines') airlineModal.openModal();
+        else if (activeTab === 'organizations') organizationModal.openModal();
     };
 
     const handleCreate = () => {
@@ -64,6 +77,7 @@ export default function AdminView() {
         if (activeTab === 'users') userModal.openModal();
         else if (activeTab === 'airports') airportModal.openModal();
         else if (activeTab === 'airlines') airlineModal.openModal();
+        else if (activeTab === 'organizations') organizationModal.openModal();
     };
 
     const handleDelete = async (id) => {
@@ -71,10 +85,16 @@ export default function AdminView() {
         try {
             if (activeTab === 'airports') await apiClient.delete(`/master/airports/${id}`);
             else if (activeTab === 'airlines') await apiClient.delete(`/master/airlines/${id}`);
+            else if (activeTab === 'organizations') await apiClient.delete(`/organizations/${id}`);
             handleSaved();
         } catch {
             alert('삭제에 실패했습니다.');
         }
+    };
+
+    const handleReviewSubmission = (item) => {
+        setSelectedItem(item);
+        submissionModal.openModal();
     };
 
     const renderUsers = () => (
@@ -245,6 +265,113 @@ export default function AdminView() {
         </>
     );
 
+    const renderOrganizations = () => (
+        <>
+            {/* Desktop Table */}
+            <div className="hidden sm:block overflow-x-auto">
+                <table className="w-full text-sm text-left border-collapse">
+                    <thead>
+                        <tr className="bg-muted/50 border-b text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                            <th className="px-6 py-4">단체명</th>
+                            <th className="px-6 py-4">상태</th>
+                            <th className="px-6 py-4 text-right">관리</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border/50">
+                        {organizations.map(o => (
+                            <tr key={o.id} className="hover:bg-muted/30 transition-colors">
+                                <td className="px-6 py-4 font-bold">{o.name}</td>
+                                <td className="px-6 py-4 text-xs">{o.is_active ? '✅ 활성' : '❌ 중지'}</td>
+                                <td className="px-6 py-4 text-right">
+                                    <div className="flex items-center justify-end gap-2">
+                                        <button className="px-2.5 py-1 text-[11px] font-bold rounded-lg bg-secondary text-secondary-foreground border border-border hover:bg-muted transition-all active:scale-95" onClick={() => handleEdit(o)}>수정</button>
+                                        <button className="px-2.5 py-1 text-[11px] font-bold rounded-lg bg-destructive/10 text-destructive border border-destructive/20 hover:bg-destructive/20 transition-all active:scale-95" onClick={() => handleDelete(o.id)}>삭제</button>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            {/* Mobile Cards */}
+            <div className="sm:hidden divide-y divide-border">
+                {organizations.map(o => (
+                    <div key={o.id} className="p-4 space-y-3">
+                        <div className="flex items-center justify-between">
+                            <span className="font-bold text-foreground">{o.name}</span>
+                            <span className="text-[10px] font-bold">{o.is_active ? '✅ 사용 중' : '❌ 중지됨'}</span>
+                        </div>
+                        <div className="flex items-center justify-end gap-2">
+                            <button className="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-secondary border border-border" onClick={() => handleEdit(o)}>수정</button>
+                            <button className="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-destructive/10 text-destructive border border-destructive/20" onClick={() => handleDelete(o.id)}>삭제</button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </>
+    );
+
+    const submissionStatusLabel = (status) => {
+        if (status === 'approved') return '✅ 승인됨';
+        if (status === 'rejected') return '❌ 반려됨';
+        return '⏳ 검토 대기';
+    };
+
+    const verificationMethodLabel = (method) => method === 'eticket_image' ? '📷 이미지' : '🔢 예약번호';
+
+    const renderSubmissions = () => (
+        <>
+            {/* Desktop Table */}
+            <div className="hidden sm:block overflow-x-auto">
+                <table className="w-full text-sm text-left border-collapse">
+                    <thead>
+                        <tr className="bg-muted/50 border-b text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                            <th className="px-6 py-4">전화번호</th>
+                            <th className="px-6 py-4">증빙 방법</th>
+                            <th className="px-6 py-4">지정 단체</th>
+                            <th className="px-6 py-4">상태</th>
+                            <th className="px-6 py-4">제출일</th>
+                            <th className="px-6 py-4 text-right">관리</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border/50">
+                        {submissions.map(s => (
+                            <tr key={s.id} className="hover:bg-muted/30 transition-colors">
+                                <td className="px-6 py-4 font-semibold text-foreground">{s.phone}</td>
+                                <td className="px-6 py-4 text-xs">{verificationMethodLabel(s.verification_method)}</td>
+                                <td className="px-6 py-4 text-muted-foreground">{s.organization?.name || '미지정'}</td>
+                                <td className="px-6 py-4 text-xs">{submissionStatusLabel(s.status)}</td>
+                                <td className="px-6 py-4 text-muted-foreground text-xs">{new Date(s.submitted_at).toLocaleDateString()}</td>
+                                <td className="px-6 py-4 text-right">
+                                    <button className="px-2.5 py-1 text-[11px] font-bold rounded-lg bg-secondary text-secondary-foreground border border-border hover:bg-muted transition-all active:scale-95" onClick={() => handleReviewSubmission(s)}>
+                                        {s.status === 'pending' ? '검토' : '상세'}
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            {/* Mobile Cards */}
+            <div className="sm:hidden divide-y divide-border">
+                {submissions.map(s => (
+                    <div key={s.id} className="p-4 space-y-2">
+                        <div className="flex items-center justify-between">
+                            <span className="font-bold text-foreground">{s.phone}</span>
+                            <span className="text-[10px] font-bold">{submissionStatusLabel(s.status)}</span>
+                        </div>
+                        <div className="text-xs text-muted-foreground">{verificationMethodLabel(s.verification_method)} · {s.organization?.name || '단체 미지정'}</div>
+                        <div className="flex items-center justify-end">
+                            <button className="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-secondary border border-border" onClick={() => handleReviewSubmission(s)}>
+                                {s.status === 'pending' ? '검토' : '상세'}
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </>
+    );
+
     return (
         <div className="space-y-6">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -252,12 +379,14 @@ export default function AdminView() {
                     <h1 className="text-2xl font-bold tracking-tight text-foreground">시스템 관리</h1>
                     <p className="text-sm text-muted-foreground">회원 및 마스터 데이터를 관리합니다.</p>
                 </div>
-                <button 
-                    className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold transition-colors rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm" 
-                    onClick={handleCreate}
-                >
-                    + {activeTab === 'users' ? '회원 등록' : activeTab === 'airports' ? '공항 등록' : '항공사 등록'}
-                </button>
+                {activeTab !== 'submissions' && (
+                    <button
+                        className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold transition-colors rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm"
+                        onClick={handleCreate}
+                    >
+                        + {activeTab === 'users' ? '회원 등록' : activeTab === 'airports' ? '공항 등록' : activeTab === 'airlines' ? '항공사 등록' : '단체 등록'}
+                    </button>
+                )}
             </div>
 
             <div className="flex flex-col bg-card rounded-xl border-2 border-border shadow-sm overflow-hidden min-h-[400px]">
@@ -274,11 +403,23 @@ export default function AdminView() {
                     >
                         🏢 공항
                     </button>
-                    <button 
+                    <button
                         className={`shrink-0 px-4 py-3 text-xs font-bold transition-all border-b-2 -mb-[2px] ${activeTab === 'airlines' ? 'text-primary border-primary' : 'text-muted-foreground border-transparent hover:text-foreground'}`}
                         onClick={() => setActiveTab('airlines')}
                     >
                         ✈️ 항공사
+                    </button>
+                    <button
+                        className={`shrink-0 px-4 py-3 text-xs font-bold transition-all border-b-2 -mb-[2px] ${activeTab === 'organizations' ? 'text-primary border-primary' : 'text-muted-foreground border-transparent hover:text-foreground'}`}
+                        onClick={() => setActiveTab('organizations')}
+                    >
+                        🏢 단체
+                    </button>
+                    <button
+                        className={`shrink-0 px-4 py-3 text-xs font-bold transition-all border-b-2 -mb-[2px] ${activeTab === 'submissions' ? 'text-primary border-primary' : 'text-muted-foreground border-transparent hover:text-foreground'}`}
+                        onClick={() => setActiveTab('submissions')}
+                    >
+                        📋 제출 검토
                     </button>
                 </div>
 
@@ -295,7 +436,9 @@ export default function AdminView() {
                         </div>
                     ) : (
                         activeTab === 'users' ? renderUsers() :
-                        activeTab === 'airports' ? renderAirports() : renderAirlines()
+                        activeTab === 'airports' ? renderAirports() :
+                        activeTab === 'airlines' ? renderAirlines() :
+                        activeTab === 'organizations' ? renderOrganizations() : renderSubmissions()
                     )}
                 </div>
             </div>
@@ -303,6 +446,8 @@ export default function AdminView() {
             <RegisterUserModal isOpen={userModal.isOpen} onClose={userModal.closeModal} onUserRegistered={handleSaved} />
             <AirportModal isOpen={airportModal.isOpen} onClose={airportModal.closeModal} airport={selectedItem} onSaved={handleSaved} apiClient={apiClient} />
             <AirlineModal isOpen={airlineModal.isOpen} onClose={airlineModal.closeModal} airline={selectedItem} onSaved={handleSaved} apiClient={apiClient} />
+            <OrganizationModal isOpen={organizationModal.isOpen} onClose={organizationModal.closeModal} organization={selectedItem} onSaved={handleSaved} apiClient={apiClient} />
+            <GuestSubmissionReviewModal isOpen={submissionModal.isOpen} onClose={submissionModal.closeModal} submission={selectedItem} onReviewed={handleSaved} />
         </div>
     );
 }

--- a/frontend/src/pages/GuestTicketSubmitView.jsx
+++ b/frontend/src/pages/GuestTicketSubmitView.jsx
@@ -1,0 +1,225 @@
+import { useState, useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import SelectField from '../components/ui/SelectField';
+import logo from '../assets/flight-app.PNG';
+
+export default function GuestTicketSubmitView() {
+    const { apiClient } = useAuth();
+    const [searchParams] = useSearchParams();
+    const orgSlug = searchParams.get('org');
+
+    const [organizations, setOrganizations] = useState([]);
+    const [lockedOrganization, setLockedOrganization] = useState(null); // slug로 고정된 단체
+    const [orgLookupFailed, setOrgLookupFailed] = useState(false);
+    const [form, setForm] = useState({
+        phone: '',
+        verificationMethod: 'eticket_image',
+        reservationNumber: '',
+        passengerNameEn: '',
+        organizationId: ''
+    });
+    const [imageFile, setImageFile] = useState(null);
+    const [error, setError] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
+
+    useEffect(() => {
+        if (orgSlug) {
+            apiClient.get(`/organizations/by-slug/${orgSlug}`)
+                .then(res => {
+                    setLockedOrganization(res.data);
+                    setForm(prev => ({ ...prev, organizationId: String(res.data.id) }));
+                })
+                .catch(() => setOrgLookupFailed(true));
+        } else {
+            apiClient.get('/organizations')
+                .then(res => setOrganizations(res.data.filter(o => o.is_active)))
+                .catch(() => setOrganizations([]));
+        }
+    }, [apiClient, orgSlug]);
+
+    const handleChange = (field, value) => {
+        setForm(prev => ({ ...prev, [field]: value }));
+    };
+
+    const handleSubmit = async () => {
+        setError('');
+        if (!form.phone.trim()) {
+            setError('전화번호를 입력해주세요.');
+            return;
+        }
+        if (form.verificationMethod === 'eticket_image') {
+            if (!imageFile) {
+                setError('e티켓 이미지를 첨부해주세요.');
+                return;
+            }
+        } else {
+            if (!form.reservationNumber.trim() || !form.passengerNameEn.trim()) {
+                setError('예약번호와 탑승객 영문명을 모두 입력해주세요.');
+                return;
+            }
+        }
+
+        const formData = new FormData();
+        formData.append('phone', form.phone);
+        formData.append('verification_method', form.verificationMethod);
+        if (form.verificationMethod === 'eticket_image') {
+            formData.append('eticket_image', imageFile);
+        } else {
+            formData.append('reservation_number', form.reservationNumber);
+            formData.append('passenger_name_en', form.passengerNameEn);
+        }
+        if (form.organizationId) {
+            formData.append('organization_id', form.organizationId);
+        }
+
+        setSubmitting(true);
+        try {
+            await apiClient.post('/guest-submissions', formData);
+            setSubmitted(true);
+        } catch (err) {
+            setError(err.response?.data?.detail || '제출에 실패했습니다.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="min-h-screen flex flex-col bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-sky/10 via-background to-earth/5">
+            <div className="flex-1 flex items-center justify-center p-4">
+                <div className="w-full max-w-[480px] p-8 space-y-8 bg-card rounded-2xl border-2 border-border shadow-xl animate-in fade-in zoom-in-95 duration-500">
+                    <div className="flex flex-col items-center text-center space-y-2">
+                        <div className="flex items-center justify-center w-14 h-14 rounded-2xl text-primary-foreground text-2xl font-bold mb-2">
+                            <img src={logo} alt="" />
+                        </div>
+                        <h1 className="text-2xl font-bold tracking-tight text-foreground">이동봉사 티켓 제공하기</h1>
+                        <p className="text-sm text-muted-foreground">로그인 없이 이동봉사 가능한 항공권 정보를 제출할 수 있습니다.<br />관리자 검토 후 정식 티켓으로 등록됩니다.</p>
+                    </div>
+
+                    {submitted ? (
+                        <div className="p-6 rounded-xl border-2 border-green/20 bg-green/5 text-center space-y-2 animate-in fade-in duration-500">
+                            <div className="text-2xl">✅</div>
+                            <div className="text-sm font-bold text-green">제출이 완료되었습니다!</div>
+                            <div className="text-xs text-muted-foreground">관리자 검토 후 남겨주신 연락처로 안내드리겠습니다.</div>
+                        </div>
+                    ) : (
+                        <div className="space-y-6">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                    전화번호<span className="text-destructive ml-0.5">*</span>
+                                </label>
+                                <input
+                                    className="flex h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    value={form.phone}
+                                    onChange={e => handleChange('phone', e.target.value)}
+                                    placeholder="예약 시 남기신 전화번호"
+                                />
+                            </div>
+
+                            <div className="space-y-3">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">증빙 방법</label>
+                                <div className="flex gap-3">
+                                    <button
+                                        className={`flex-1 flex items-center justify-center gap-2 h-11 rounded-lg border-2 transition-all text-sm font-semibold ${form.verificationMethod === 'eticket_image' ? 'bg-primary/5 border-primary text-primary' : 'bg-background border-border text-muted-foreground hover:border-primary/30'}`}
+                                        onClick={() => handleChange('verificationMethod', 'eticket_image')}
+                                    >
+                                        e티켓 이미지
+                                    </button>
+                                    <button
+                                        className={`flex-1 flex items-center justify-center gap-2 h-11 rounded-lg border-2 transition-all text-sm font-semibold ${form.verificationMethod === 'reservation_number' ? 'bg-primary/5 border-primary text-primary' : 'bg-background border-border text-muted-foreground hover:border-primary/30'}`}
+                                        onClick={() => handleChange('verificationMethod', 'reservation_number')}
+                                    >
+                                        예약번호
+                                    </button>
+                                </div>
+                            </div>
+
+                            {form.verificationMethod === 'eticket_image' ? (
+                                <div className="space-y-2">
+                                    <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                        e티켓 이미지<span className="text-destructive ml-0.5">*</span>
+                                    </label>
+                                    <input
+                                        className="flex w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-xs file:font-bold file:bg-primary file:text-primary-foreground"
+                                        type="file"
+                                        accept="image/*,application/pdf"
+                                        onChange={e => setImageFile(e.target.files?.[0] || null)}
+                                    />
+                                </div>
+                            ) : (
+                                <div className="space-y-4">
+                                    <div className="space-y-2">
+                                        <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                            예약번호<span className="text-destructive ml-0.5">*</span>
+                                        </label>
+                                        <input
+                                            className="flex h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                            value={form.reservationNumber}
+                                            onChange={e => handleChange('reservationNumber', e.target.value)}
+                                            placeholder="예: ABC123"
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">
+                                            탑승객 영문명<span className="text-destructive ml-0.5">*</span>
+                                        </label>
+                                        <input
+                                            className="flex h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                            value={form.passengerNameEn}
+                                            onChange={e => handleChange('passengerNameEn', e.target.value)}
+                                            placeholder="예: HONG GILDONG"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+
+                            {lockedOrganization ? (
+                                <div className="space-y-2">
+                                    <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">소속 단체</label>
+                                    <div className="flex items-center gap-2 h-11 px-4 rounded-lg border-2 border-primary/30 bg-primary/5 text-sm font-bold text-primary">
+                                        🏢 {lockedOrganization.name}
+                                    </div>
+                                </div>
+                            ) : (
+                                <>
+                                    <SelectField
+                                        label="소속 단체 (선택)"
+                                        options={organizations.map(o => ({ value: String(o.id), label: o.name }))}
+                                        value={form.organizationId}
+                                        onChange={val => handleChange('organizationId', val)}
+                                        placeholder="소속된 단체가 있다면 선택해주세요"
+                                        isCreatable={false}
+                                    />
+                                    {orgLookupFailed && (
+                                        <div className="px-3 py-2 text-[11px] font-medium text-destructive bg-destructive/10 border border-destructive/20 rounded-lg">
+                                            링크에 지정된 단체를 찾을 수 없어요. 직접 선택해주세요.
+                                        </div>
+                                    )}
+                                </>
+                            )}
+
+                            {error && (
+                                <div className="px-3 py-2 text-xs font-medium text-destructive bg-destructive/10 border border-destructive/20 rounded-lg animate-in shake duration-300">
+                                    {error}
+                                </div>
+                            )}
+
+                            <button
+                                className="w-full inline-flex items-center justify-center h-11 px-4 py-2 text-sm font-bold transition-all rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20 hover:scale-[0.99] active:scale-[0.97] disabled:opacity-50"
+                                onClick={handleSubmit}
+                                disabled={submitting}
+                            >
+                                {submitting ? '제출 중...' : '제출하기'}
+                            </button>
+                        </div>
+                    )}
+
+                    <div className="text-center pt-2">
+                        <Link to="/" className="text-xs text-muted-foreground hover:text-foreground transition-colors">← 로그인 화면으로 돌아가기</Link>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/LoginScreen.jsx
+++ b/frontend/src/pages/LoginScreen.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import logo from '../assets/flight-app.PNG';
 import Footer from '../components/layout/Footer';
@@ -67,11 +68,14 @@ export default function LoginScreen() {
                         </button>
                     </form>
 
-                    <div className="text-center space-y-1 pt-4">
+                    <div className="text-center space-y-3 pt-4">
                         <p className="text-xs text-muted-foreground leading-relaxed">
                             계정이 없으신가요? 관리자에게 문의하세요.<br />
                             <span className="font-medium">계정은 관리자만 발급할 수 있습니다.</span>
                         </p>
+                        <Link to="/apply" className="inline-block text-xs font-bold text-primary hover:underline">
+                            🎁 봉사 티켓을 제출하고 싶으신가요? →
+                        </Link>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- 단체 계정 없이도 e티켓 이미지/예약번호로 이동봉사 티켓을 제출할 수 있는 공개 폼 추가
- 단체별 전용 제출 링크(슬러그) 지원, 기존 회원 organization 값으로 단체 목록 자동 백필
- 관리자 승인/반려 플로우 및 단체 마스터 데이터 관리 화면 추가
- e티켓 이미지는 MinIO에 저장하고 대표 관리자 구글 드라이브에 백업 업로드
- SQLite에서 실패하던 004 마이그레이션(ALTER COLUMN) 수정