### PR TITLE
feat: 카카오톡 아이디 필드 추가, 달력 공유 이미지에 공항 색상 범례 추가

### DIFF
--- a/backend/alembic/versions/007_add_kakao_id_to_guest_submission.py
+++ b/backend/alembic/versions/007_add_kakao_id_to_guest_submission.py
@@ -1,0 +1,28 @@
+"""Add kakao_id to guest ticket submissions
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-07-25 07:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guest_ticket_submissions", sa.Column("kakao_id", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guest_ticket_submissions", "kakao_id")

--- a/backend/models.py
+++ b/backend/models.py
@@ -231,6 +231,7 @@ class GuestTicketSubmission(Base):
 
     id = Column(String, primary_key=True, default=generate_uuid)
     phone = Column(String, nullable=False)
+    kakao_id = Column(String, nullable=True)  # 카카오톡 아이디 (선택)
     airline = Column(String, nullable=True)  # 항공사 코드 (마스터 데이터 참조)
     verification_method = Column(String, nullable=False, index=True)  # 'eticket_image', 'reservation_number'
     eticket_object_key = Column(String, nullable=True)  # MinIO 오브젝트 키

--- a/backend/routers/guest_submissions.py
+++ b/backend/routers/guest_submissions.py
@@ -38,6 +38,7 @@ async def create_guest_submission(
     phone: Annotated[str, Form()],
     airline: Annotated[str, Form()],
     verification_method: Annotated[schemas.GuestSubmissionVerificationMethod, Form()],
+    kakao_id: Annotated[str | None, Form()] = None,
     reservation_number: Annotated[str | None, Form()] = None,
     passenger_last_name_en: Annotated[str | None, Form()] = None,
     passenger_first_name_en: Annotated[str | None, Form()] = None,
@@ -106,6 +107,7 @@ async def create_guest_submission(
     )
     db_submission = models.GuestTicketSubmission(
         phone=phone,
+        kakao_id=kakao_id,
         airline=airline,
         verification_method=verification_method.value,
         eticket_object_key=eticket_object_key,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -385,6 +385,7 @@ class GuestSubmissionStatus(str, Enum):
 class GuestTicketSubmission(BaseModel):
     id: str
     phone: str
+    kakao_id: str | None = None
     airline: str | None = None
     verification_method: GuestSubmissionVerificationMethod
     reservation_number: str | None = None

--- a/frontend/src/components/CalendarView.jsx
+++ b/frontend/src/components/CalendarView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuth } from '../hooks/useAuth';
-import { getAirportColor } from '../utils/airportUtils';
+import { getAirportColor, MAJOR_AIRPORTS } from '../utils/airportUtils';
 
 export default function CalendarView({ 
     tickets, 
@@ -48,6 +48,18 @@ export default function CalendarView({
     for (let i = 1; i <= remaining; i++) {
         days.push({ day: i, otherMonth: true });
     }
+
+    // 이번 달에 실제로 등장하는 공항들만 색상 범례로 표시 (정렬: 주요 공항 우선, 이후 가나다순)
+    const monthAirportCodes = [...new Set(
+        days.filter(d => !d.otherMonth).flatMap(d => d.tickets || []).map(t => t.arrival_airport).filter(Boolean)
+    )].sort((a, b) => {
+        const aIdx = MAJOR_AIRPORTS.indexOf(a);
+        const bIdx = MAJOR_AIRPORTS.indexOf(b);
+        if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
+        if (aIdx !== -1) return -1;
+        if (bIdx !== -1) return 1;
+        return a.localeCompare(b);
+    });
 
     const prevMonth = () => setCurrentDate(new Date(year, month - 1, 1));
     const nextMonth = () => setCurrentDate(new Date(year, month + 1, 1));
@@ -128,6 +140,23 @@ export default function CalendarView({
                         </div>
                     ))}
                 </div>
+
+                {monthAirportCodes.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 border-t bg-background/50">
+                        {monthAirportCodes.map(code => {
+                            const colors = getAirportColor(code, rawAirports);
+                            return (
+                                <div key={code} className="flex items-center gap-1.5 text-[11px] font-semibold text-muted-foreground">
+                                    <span
+                                        className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                                        style={{ backgroundColor: colors.bg, border: `1px solid ${colors.text}` }}
+                                    />
+                                    {code}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/components/modals/GuestSubmissionReviewModal.jsx
+++ b/frontend/src/components/modals/GuestSubmissionReviewModal.jsx
@@ -162,6 +162,9 @@ export default function GuestSubmissionReviewModal({ isOpen, onClose, submission
                 <div className="p-4 rounded-xl border-2 border-border bg-muted/30 space-y-2">
                     <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">제출 정보</div>
                     <div className="text-sm"><span className="font-bold">전화번호:</span> {submission.phone}</div>
+                    {submission.kakao_id && (
+                        <div className="text-sm"><span className="font-bold">카카오톡 아이디:</span> {submission.kakao_id}</div>
+                    )}
                     <div className="text-sm"><span className="font-bold">항공사(제출자 입력):</span> {submission.airline || '-'}</div>
                     {submission.organization && (
                         <div className="text-sm"><span className="font-bold">지정 단체:</span> {submission.organization.name}</div>

--- a/frontend/src/pages/GuestTicketSubmitView.jsx
+++ b/frontend/src/pages/GuestTicketSubmitView.jsx
@@ -44,6 +44,7 @@ export default function GuestTicketSubmitView() {
     const [orgLookupFailed, setOrgLookupFailed] = useState(false);
     const [form, setForm] = useState({
         phone: '',
+        kakaoId: '',
         airline: '',
         verificationMethod: 'eticket_image',
         reservationNumber: '',
@@ -99,6 +100,9 @@ export default function GuestTicketSubmitView() {
 
         const formData = new FormData();
         formData.append('phone', form.phone);
+        if (form.kakaoId.trim()) {
+            formData.append('kakao_id', form.kakaoId);
+        }
         formData.append('airline', form.airline);
         formData.append('verification_method', form.verificationMethod);
         if (form.verificationMethod === 'eticket_image') {
@@ -231,6 +235,16 @@ export default function GuestTicketSubmitView() {
                                     value={form.phone}
                                     onChange={e => handleChange('phone', e.target.value)}
                                     placeholder="예약 시 남기신 전화번호"
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground ml-1">카카오톡 아이디 (선택)</label>
+                                <input
+                                    className="flex h-11 w-full rounded-lg border-2 border-border bg-background px-4 py-2 text-sm transition-all focus:border-primary/50 focus-visible:outline-none"
+                                    value={form.kakaoId}
+                                    onChange={e => handleChange('kakaoId', e.target.value)}
+                                    placeholder="카카오톡으로 연락받고 싶다면 아이디를 남겨주세요"
                                 />
                             </div>
 


### PR DESCRIPTION
- 비로그인 제출 폼에 카카오톡 아이디(선택) 입력란 추가, 관리자 검토 화면에도 표시. 007 마이그레이션으로 guest_ticket_submissions에 kakao_id 컬럼 추가.
- 일정 공유하기(이미지 내보내기) 기능에서, 이번 달에 실제로 등장하는 공항들의 색상-코드 범례를 달력 하단에 추가. 기존 셀 색상 로직은 변경 없음.